### PR TITLE
Padronização dos Controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,26 +1,26 @@
 import { InternalServerError, MethodNotAllowedError } from "infra/errors";
 
 function onNoMatchHandler(request, response) {
-    const publicErrorObject = new MethodNotAllowedError();
-    response.status(publicErrorObject.status_code).json(publicErrorObject);
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.status_code).json(publicErrorObject);
 }
 
 function onErrorHandler(error, request, response) {
-    const publicErrorObject = new InternalServerError({
-        statusCode: error.statusCode,
-        cause: error,
-    });
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
 
-    console.error(publicErrorObject);
+  console.error(publicErrorObject);
 
-    response.status(publicErrorObject.statusCode).json(publicErrorObject);
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
 }
 
 const controller = {
-    errorHandlers: {
-        onNoMatch: onNoMatchHandler,
-        onError: onErrorHandler,
-    }
-}
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
 
 export default controller;

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,26 @@
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+
+function onNoMatchHandler(request, response) {
+    const publicErrorObject = new MethodNotAllowedError();
+    response.status(publicErrorObject.status_code).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+    const publicErrorObject = new InternalServerError({
+        statusCode: error.statusCode,
+        cause: error,
+    });
+
+    console.error(publicErrorObject);
+
+    response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+    errorHandlers: {
+        onNoMatch: onNoMatchHandler,
+        onError: onErrorHandler,
+    }
+}
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -11,7 +11,7 @@ async function query(queryObject) {
     const serviceErrorObject = new ServiceError({
       message: "Erro na conexão com Banco ou na Query.",
       cause: error,
-    })
+    });
     throw serviceErrorObject;
   } finally {
     await client?.end();

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors";
 
 async function query(queryObject) {
   let client;
@@ -7,9 +8,11 @@ async function query(queryObject) {
     const result = await client.query(queryObject);
     return result;
   } catch (error) {
-    console.log("\n Erro dentro do catch do database:");
-    console.error(error);
-    throw error;
+    const serviceErrorObject = new ServiceError({
+      message: "Erro na conexão com Banco ou na Query.",
+      cause: error,
+    })
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,11 +1,11 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Um erro interno não esperado aconteceu.", {
       cause,
     });
     this.name = "Internal Server Error";
     this.action = "Entre em contato com o suporte.";
-    this.status_code = 500;
+    this.statusCode = statusCode || 500;
   }
 
   toJSON() {
@@ -13,7 +13,46 @@ export class InternalServerError extends Error {
       name: this.name,
       message: this.message,
       action: this.action,
-      status_code: this.status_code,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Serviço indisponível no momento.", {
+      cause,
+    });
+    this.name = "ServiceError";
+    this.action = "Verifique se o serviço esta disponível.";
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para esse endpoint.");
+    this.name = "MethodNotAllowedError";
+    this.action =
+      "Verifique se o método HTTP enviado é válido para esse endpoint.";
+    this.statusCode = 405;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
     };
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.7",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2097,6 +2098,11 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8578,6 +8584,18 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9617,6 +9635,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.7",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -25,8 +25,8 @@ async function getHandler(request, response) {
   try {
     dbClient = await database.getNewClient();
     const pendingMigrations = await migrationRunner({
-      ...defaultMigrations, 
-      dbClient
+      ...defaultMigrations,
+      dbClient,
     });
     return response.status(200).json(pendingMigrations);
   } finally {
@@ -42,7 +42,7 @@ async function postHandler(request, response) {
     const migratedMigrations = await migrationRunner({
       ...defaultMigrations,
       dryRun: false,
-      dbClient
+      dbClient,
     });
     if (migratedMigrations.length > 0) {
       return response.status(201).json(migratedMigrations);

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,48 +1,53 @@
+import { createRouter } from "next-connect";
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database";
+import controller from "infra/controller";
 
-export default async function migrations(request, response) {
-  const allowedMethods = ["GET", "POST"];
-  if (!allowedMethods.includes(request.method)) {
-    return response.status(405).json({
-      error: `Method "${request.method}" not allowed`,
-    });
-  }
+const router = createRouter();
 
+router.get(getHandler);
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers);
+
+const defaultMigrations = {
+  dryRun: true,
+  dir: resolve("infra", "migrations"),
+  direction: "up",
+  verbose: true,
+  migrationsTable: "pgmigrations",
+};
+
+async function getHandler(request, response) {
   let dbClient;
 
   try {
     dbClient = await database.getNewClient();
-    const defaultMigrations = {
-      dbClient: dbClient,
-      dryRun: true,
-      dir: resolve("infra", "migrations"),
-      direction: "up",
-      verbose: true,
-      migrationsTable: "pgmigrations",
-    };
-    switch (request.method) {
-      case "GET": {
-        const pendingMigrations = await migrationRunner(defaultMigrations);
-        return response.status(200).json(pendingMigrations);
-      }
-      case "POST": {
-        const migratedMigrations = await migrationRunner({
-          ...defaultMigrations,
-          dryRun: false,
-        });
-        if (migratedMigrations.length > 0) {
-          return response.status(201).json(migratedMigrations);
-        }
-        return response.status(200).json(migratedMigrations);
-      }
-      default:
-        break;
+    const pendingMigrations = await migrationRunner({
+      ...defaultMigrations, 
+      dbClient
+    });
+    return response.status(200).json(pendingMigrations);
+  } finally {
+    await dbClient.end();
+  }
+}
+
+async function postHandler(request, response) {
+  let dbClient;
+
+  try {
+    dbClient = await database.getNewClient();
+    const migratedMigrations = await migrationRunner({
+      ...defaultMigrations,
+      dryRun: false,
+      dbClient
+    });
+    if (migratedMigrations.length > 0) {
+      return response.status(201).json(migratedMigrations);
     }
-  } catch (error) {
-    console.error(error);
-    throw error;
+    return response.status(200).json(migratedMigrations);
   } finally {
     await dbClient.end();
   }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,29 +1,23 @@
+import { createRouter } from "next-connect";
 import database from "infra/database.js";
-import { InternalServerError } from "infra/errors";
+import controller from "infra/controller.js";
 
-async function status(request, response) {
-  try {
-    const updatedAt = new Date().toISOString();
-    response.status(200).json({
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          version: await database.getDatabaseVersion(),
-          max_connections: await database.getMaxConnections(),
-          opened_connections: await database.getUsedConnections(),
-        },
+const router = createRouter();
+
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(request, response) {
+  const updatedAt = new Date().toISOString();
+  response.status(200).json({
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        version: await database.getDatabaseVersion(),
+        max_connections: await database.getMaxConnections(),
+        opened_connections: await database.getUsedConnections(),
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-
-    console.log("\n Erro dentro do catch do controller:");
-    console.error(publicErrorObject);
-
-    response.status(500).json(publicErrorObject);
-  }
+    },
+  });
 }
-
-export default status;


### PR DESCRIPTION
1. Padroniza os Controllers dos endpoints `/migrations` e `/status`.
2. Adiciona 2 novos erros customizados: `MethodNotAllowerError` e `ServiceError`.
3. Faz o `InternalServerError` aceitar injeção do `statusCode`.